### PR TITLE
fix memory leak

### DIFF
--- a/src/BlendFilter.ts
+++ b/src/BlendFilter.ts
@@ -18,8 +18,6 @@ export class BackdropFilter extends Filter
     backdropUniformName: string = null;
 
     trivial = false;
-    /** @ignore */
-    _backdropActive = false;
 
     /** If non-null, @pixi/picture will clear the filter's output framebuffer with this RGBA color. */
     clearColor: Float32Array = null;


### PR DESCRIPTION
When the parent element and the child element use the same blendFilter, the backdrop in the blendFilter will be overwritten. The overwritten backdrop cannot be recycled by the pool, resulting in leakage.

The following is a simple example that reproduces the problem.
import * as PIXI from 'pixi.js';
import {Sprite, getBlendFilter} from '@pixi/picture';
// hacked sprite or tilingSprite
const sprite = new Sprite();
sprite.blendMode = PIXI.BLEND_MODES.OVERLAY;
// for other kind of elements
const graphics = new PIXI.Graphics();
graphics.filters = [getBlendFilter(PIXI.BLEND_MODES.OVERLAY)];